### PR TITLE
merge org/repo/path flags into a single pos arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # tftrigger
-Small tool that trigger the threefold auto-build for a specific branch/commit
+Small tool that trigger the threefold auto-build for a specific repo, branch and commit.
 
 ## Usage
 ```
@@ -7,7 +7,7 @@ NAME:
    tftrigger - A new cli application
 
 USAGE:
-   tftrigger [global options] command [command options] [arguments...]
+   tftrigger [global options] command [command options] [path|ghrepo]
 
 VERSION:
    0.0.0
@@ -16,23 +16,33 @@ COMMANDS:
      help, h  Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
-   --organization value, -o value  github organization (default: "threefoldtech")
-   --repository value, -r value    repository name
-   --commit value, -c value        commit hash
-   --branch value, -b value        branch to use for the build (default: "master")
-   --path value, -p value          specified the path of the repository to use as source of information for the build
-   --help, -h                      show help
-   --version, -v                   print the version
+   --commit value, -c value  commit hash
+   --branch value, -b value  branch to use for the build (default: "master")
+   --help, -h                show help
+   --version, -v             print the version
 ```
 
-To manually choose which repository,branch and commit id:
+To Manually choose which repository:
 ```
-tftrigger --organization threefoldtech --repository my_repo --branch master --commit 28275d75474ea6a4639d46e9ac393e664065feda
+tftrigger threefoldtech/my_repo
 ```
 
-But if you are working on a project and want to quicly trigger a build, you can use the `--path` flag to specified the path of a git repository. Tftrigger will read the information from the `.git` directory and trigger the build for the repository, the current checkout branch and revision
-
-Example: this command will trigger a build for the repository in the current directory
+To manually choose which repository, branch and commit id:
 ```
-tftrigger -p .
+tftrigger--branch master --commit 28275d75474ea6a4639d46e9ac393e664065feda threefoldtech/my_repo
+```
+
+But if you are working on a project and want to quickly trigger a build,
+you can give a specified the path of a git repository.
+Tftrigger will read the information from the `.git` directory and trigger the build for the repository,
+the current checkout branch and revision:
+```
+tftrigger /home/me/a/path/to/a/git/repo
+```
+
+Running the `tftrigger` command without a position argument will assume the
+current working directory is the path of a git repo from which
+trigger the threefold auto-build for a specific branch/commit:
+```
+tftrigger
 ```


### PR DESCRIPTION
It seemed not ideal for the UX that all info was given via flags, especially as currently one of two situations was assumed as far as I could see:

- either the user gives the path flag;
- or the user gives both the org and repo flag.

To put required parameters as flags already triggers a warning I would say. However, it also prevents the implicit option of triggering from the current path by default.

This PR adds a single string param, which can be:

- empty (assumed to mean current working dir);
- a FS path (assumed to be a directory containing a valid GitHub dir);
- a GitHub full name in the form of org/repo;